### PR TITLE
Removed null chars from output

### DIFF
--- a/Ruby/example.rb
+++ b/Ruby/example.rb
@@ -1,4 +1,4 @@
-require_relative 'minestat'
+require 'minestat'
 
 # Below is an example using the MineStat class.
 # If server is offline, other instance members will be nil.

--- a/Ruby/lib/minestat.rb
+++ b/Ruby/lib/minestat.rb
@@ -53,10 +53,10 @@ class MineStat
       server_info = data.split("\x00\x00\x00")
       if server_info != nil && server_info.length >= NUM_FIELDS
         @online = true
-        @version = server_info[2]
-        @motd = server_info[3]
-        @current_players = server_info[4]
-        @max_players = server_info[5]
+        @version = server_info[2].gsub("\x00",'')
+        @motd = server_info[3].gsub("\x00",'')
+        @current_players = server_info[4].gsub("\x00",'')
+        @max_players = server_info[5].gsub("\x00",'')
       else
         @online = false
       end

--- a/Ruby/minestat.gemspec
+++ b/Ruby/minestat.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "minestat"
-  s.version = "0.1.0"
+  s.version = "0.1.1"
   s.authors = ["Lloyd Dilley", "Stepan Melnikov"]
   s.summary = "Minecraft server status checker"
   s.homepage = "https://github.com/ldilley/minestat"


### PR DESCRIPTION
I've encountered null chars (`\x00`) , e.g.
```
irb(main):003:0> stat = MineStat.new("sv5.ex-server.ru",25847)
=> #<MineStat:0x00000002343b70 @address="sv5.ex-server.ru", @port=25847, @online=true, @version="1\x00.\x007\x00.\x001\x000", @motd="E\x00x\x00c\x00a\x00l\x00i\x00b\x00u\x00r\x00-\x00C\x00r\x00a\x00f\x00t\x00 \x00I\x00n\x00d\x00u\x00s\x00t\x00r\x00i\x00a\x00l\x00 \x00S\x006", @current_players="5\x001", @max_players="1\x001\x005">
``` 
and fixed it