### PR TITLE
Update MineStat.cs to be more C#-like

### DIFF
--- a/CSharp/MineStat.cs
+++ b/CSharp/MineStat.cs
@@ -38,8 +38,7 @@ public class MineStat
 
   public MineStat(string address, ushort port)
   {
-    byte[] rawServerData = new byte[dataSize];
-    string[] serverData;
+    var rawServerData = new byte[dataSize];
 
     Address = address;
     Port = port;
@@ -47,10 +46,10 @@ public class MineStat
     try
     {
       // ToDo: Add timeout
-      TcpClient tcpclient = new TcpClient();
+      var tcpclient = new TcpClient();
       tcpclient.Connect(address, port);
-      Stream stream = tcpclient.GetStream();
-      byte[] payload = { 0xFE, 0x01 };
+      var stream = tcpclient.GetStream();
+      var payload = new byte[] { 0xFE, 0x01 };
       stream.Write(payload, 0, payload.Length);
       stream.Read(rawServerData, 0, dataSize);
       tcpclient.Close();
@@ -62,10 +61,12 @@ public class MineStat
     }
 
     if(rawServerData == null || rawServerData.Length == 0)
+    {
       ServerUp = false;
+    }
     else
     {
-      serverData = Encoding.Unicode.GetString(rawServerData).Split("\u0000\u0000\u0000".ToCharArray());
+      var serverData = Encoding.Unicode.GetString(rawServerData).Split("\u0000\u0000\u0000".ToCharArray());
       if(serverData != null && serverData.Length >= numFields)
       {
         ServerUp = true;

--- a/CSharp/MineStat.cs
+++ b/CSharp/MineStat.cs
@@ -76,7 +76,9 @@ public class MineStat
         MaximumPlayers = serverData[5];
       }
       else
+      {
         ServerUp = false;
+      }
     }
   }
 

--- a/CSharp/MineStat.cs
+++ b/CSharp/MineStat.cs
@@ -27,21 +27,22 @@ public class MineStat
 {
   const ushort dataSize = 512; // this will hopefully suffice since the MotD should be <=59 characters
   const ushort numFields = 6;  // number of values expected from server
-  private string address;
-  private ushort port;
-  private bool serverUp;
-  private string motd;
-  private string version;
-  private string currentPlayers;
-  private string maximumPlayers;
+
+  public string Address { get; set; }
+  public ushort Port { get; set; }
+  public string Motd { get; set; }
+  public string Version { get; set; }
+  public string CurrentPlayers { get; set; }
+  public string MaximumPlayers { get; set; }
+  public bool ServerUp { get; set; }
 
   public MineStat(string address, ushort port)
   {
     byte[] rawServerData = new byte[dataSize];
     string[] serverData;
 
-    SetAddress(address);
-    SetPort(port);
+    Address = address;
+    Port = port;
 
     try
     {
@@ -56,90 +57,107 @@ public class MineStat
     }
     catch(Exception)
     {
-      serverUp = false;
+      ServerUp = false;
       return;
     }
 
     if(rawServerData == null || rawServerData.Length == 0)
-      serverUp = false;
+      ServerUp = false;
     else
     {
       serverData = Encoding.Unicode.GetString(rawServerData).Split("\u0000\u0000\u0000".ToCharArray());
       if(serverData != null && serverData.Length >= numFields)
       {
-        serverUp = true;
-        SetVersion(serverData[2]);
-        SetMotd(serverData[3]);
-        SetCurrentPlayers(serverData[4]);
-        SetMaximumPlayers(serverData[5]);
+        ServerUp = true;
+        Version = serverData[2];
+        Motd = serverData[3];
+        CurrentPlayers = serverData[4];
+        MaximumPlayers = serverData[5];
       }
       else
-        serverUp = false;
+        ServerUp = false;
     }
   }
 
+  #region Obsolete
+
+  [Obsolete]
   public string GetAddress()
   {
-    return address;
+    return Address;
   }
 
+  [Obsolete]
   public void SetAddress(string address)
   {
-    this.address = address;
+    Address = address;
   }
 
+  [Obsolete]
   public ushort GetPort()
   {
-    return port;
+    return Port;
   }
 
+  [Obsolete]
   public void SetPort(ushort port)
   {
-    this.port = port;
+    Port = port;
   }
 
+  [Obsolete]
   public string GetMotd()
   {
-    return motd;
+    return Motd;
   }
 
+  [Obsolete]
   public void SetMotd(string motd)
   {
-    this.motd = motd;
+    Motd = motd;
   }
 
+  [Obsolete]
   public string GetVersion()
   {
-    return version;
+    return Version;
   }
 
+  [Obsolete]
   public void SetVersion(string version)
   {
-    this.version = version;
+    Version = version;
   }
 
+  [Obsolete]
   public string GetCurrentPlayers()
   {
-    return currentPlayers;
+    return CurrentPlayers;
   }
 
+  [Obsolete]
   public void SetCurrentPlayers(string currentPlayers)
   {
-    this.currentPlayers = currentPlayers;
+    CurrentPlayers = currentPlayers;
   }
 
+  [Obsolete]
   public string GetMaximumPlayers()
   {
-    return maximumPlayers;
+    return MaximumPlayers;
   }
 
+  [Obsolete]
   public void SetMaximumPlayers(string maximumPlayers)
   {
-    this.maximumPlayers = maximumPlayers;
+    MaximumPlayers = maximumPlayers;
   }
 
+  [Obsolete]
   public bool IsServerUp()
   {
-    return serverUp;
+    return ServerUp;
   }
+
+  #endregion
 }

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ class Example
   public static void Main()
   {
     MineStat ms = new MineStat("cubekingdom.net", 25565);
-    Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.GetAddress(), ms.GetPort());
-    if(ms.IsServerUp())
+    Console.WriteLine("Minecraft server status of {0} on port {1}:", ms.Address, ms.Port);
+    if(ms.ServerUp
     {
-      Console.WriteLine("Server is online running version {0} with {1} out of {2} players.", ms.GetVersion(), ms.GetCurrentPlayers(), ms.GetMaximumPlayers());
-      Console.WriteLine("Message of the day: {0}", ms.GetMotd());
+      Console.WriteLine("Server is online running version {0} with {1} out of {2} players.", ms.Version, ms.CurrentPlayers, ms.MaximumPlayers);
+      Console.WriteLine("Message of the day: {0}", ms.Motd);
     }
     else
       Console.WriteLine("Server is offline!");


### PR DESCRIPTION
This PR updates the C# part of minestat.  
The following changes were made:

- Use of auto properties instead of private fields with getters and setters
- Slight refactoring to be more C#-like (usage of var instead of explicit types, etc.)
- `Obsolete` marking of the old getter and setter methods to maintain backwards compatibility
- Update for `README.md` to use properties instead of getter methods