### PR TITLE
Remove weird \u0000 characters  when query

### DIFF
--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -55,8 +55,8 @@ module.exports =
         if(server_info != null && server_info.length >= NUM_FIELDS)
         {
           this.online = true;
-          this.version = server_info[2];
-          this.motd = server_info[3];
+          this.version = server_info[2].replace(/\0/g,'');
+          this.motd = server_info[3].replace(/\0/g,'');
           this.current_players = server_info[4];
           this.max_players = server_info[5];
         }

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -55,10 +55,10 @@ module.exports =
         if(server_info != null && server_info.length >= NUM_FIELDS)
         {
           this.online = true;
-          this.version = server_info[2].replace(/\0/g,'');
-          this.motd = server_info[3].replace(/\0/g,'');
-          this.current_players = server_info[4].replace(/\0/g,'');
-          this.max_players = server_info[5].replace(/\0/g,'');
+          this.version = server_info[2].replace(/\u0000/g,'');
+          this.motd = server_info[3].replace(/\u0000/g,'');
+          this.current_players = server_info[4].replace(/\u0000/g,'');
+          this.max_players = server_info[5].replace(/\u0000/g,'');
         }
         else
         {

--- a/JavaScript/minestat.js
+++ b/JavaScript/minestat.js
@@ -57,8 +57,8 @@ module.exports =
           this.online = true;
           this.version = server_info[2].replace(/\0/g,'');
           this.motd = server_info[3].replace(/\0/g,'');
-          this.current_players = server_info[4];
-          this.max_players = server_info[5];
+          this.current_players = server_info[4].replace(/\0/g,'');
+          this.max_players = server_info[5].replace(/\0/g,'');
         }
         else
         {


### PR DESCRIPTION
A quick fix on the removing excessive space between characters when querying data that returns string data type