### PR TITLE
Fixed typo in minestat.php 

### DIFF
--- a/PHP/minestat.php
+++ b/PHP/minestat.php
@@ -59,7 +59,7 @@ class MineStat
       $raw_data = socket_read($socket, MineStat::DATA_SIZE);
       socket_close($socket);
     }
-    catch(Exeption $e)
+    catch(Exception $e)
     {
       $this->online = false;
       return;


### PR DESCRIPTION
Hey!

This is just a quick fix for a typo in the PHP version of minestat. ("Exception" instead of "Exeption")